### PR TITLE
docs: Document support for Kubernetes v1.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.26 | untested | N/A                      |
 | Kubernetes 1.25 | untested | N/A                      |
 
-Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
+Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ Please find more information regarding the extensibility concepts and a detailed
 
 This extension controller supports the following Kubernetes versions:
 
-| Version         | Support     | Conformance test results |
-| --------------- | ----------- | ------------------------ |
-| Kubernetes 1.30 | untested    | N/A                      |
-| Kubernetes 1.29 | untested    | N/A                      |
-| Kubernetes 1.28 | untested    | N/A                      |
-| Kubernetes 1.27 | untested    | N/A                      |
-| Kubernetes 1.26 | untested    | N/A                      |
-| Kubernetes 1.25 | untested    | N/A                      |
+| Version         | Support  | Conformance test results |
+|-----------------|----------|--------------------------|
+| Kubernetes 1.32 | untested | N/A                      |
+| Kubernetes 1.31 | untested | N/A                      |
+| Kubernetes 1.30 | untested | N/A                      |
+| Kubernetes 1.29 | untested | N/A                      |
+| Kubernetes 1.28 | untested | N/A                      |
+| Kubernetes 1.27 | untested | N/A                      |
+| Kubernetes 1.26 | untested | N/A                      |
+| Kubernetes 1.25 | untested | N/A                      |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:

This PR documents the support for Kubernetes v1.32 in the README.
Primarily added for completeness regarding the supported Kubernetes versions of Gardener.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/11020

**Special notes for your reviewer**:

The functionality has been validated as follows:
* [ ] Create new clusters with versions < 1.32
* [ ] Create new clusters with version  = 1.32
* [ ] Upgrade old clusters from version 1.31 to version 1.32
* [ ] Delete clusters with versions < 1.32
* [ ] Delete clusters with version  = 1.32

/cc @schrodit similar as in #324 I don't have access to the infrastructure. I'd appreciate it if you could validate the scenarios whenever it's possible :) 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-equinix-metal extension does now support shoot clusters with Kubernetes version 1.32. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md) before upgrading to 1.32. 
```
